### PR TITLE
Update direnv configuration to support nvm alias

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,12 @@
-# looks at .nvmrc, using nvm to active specified version
-use node
+# Use https://stackoverflow.com/a/38316441/112682
+# instead of `use node` (which does not support aliases in .nvmrc)
+# because https://github.com/direnv/direnv/issues/319
+nvmrc="$HOME/.nvm/nvm.sh"
+if [ -e "$nvmrc" ]
+then
+  source "$nvmrc"
+  nvm use
+fi
 
 # adds node_modules/.bin to PATH
 layout node


### PR DESCRIPTION
# Update `direnv` configuration

Update `.envrc` to load `nvm` and call `nvm use` itself, so that the alias in
`.nvmrc` works.  Otherwise, I have to ignore an error message:

```sh
direnv: Unable to find NodeJS version (lts/hydrogen) in (/Users/me/.nvm/versions/node/)!
direnv: error exit status 1
```

and then type `nvm use` myself, which is for chumps.
